### PR TITLE
Prevent FreeRTOS task starving

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -206,6 +206,7 @@ demo_task(void *params)
         hagl_put_text(display, message, DISPLAY_WIDTH - 60, DISPLAY_HEIGHT - 14, green, font6x9);
 
         hagl_set_clip(display, 0, 20, DISPLAY_WIDTH - 1, DISPLAY_HEIGHT - 21);
+        vTaskDelay(10 / portTICK_PERIOD_MS);
     }
 
     vTaskDelete(NULL);


### PR DESCRIPTION
In your example `demo_task`  is not allowing any free time to the other tasks.

```bash
E (8247) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (8247) task_wdt:  - IDLE1 (CPU 1)
E (8247) task_wdt: Tasks currently running:
E (8247) task_wdt: CPU 0: IDLE0
E (8247) task_wdt: CPU 1: Demo
E (8247) task_wdt: Print CPU 1 backtrace


Backtrace: 0x40085296:0x3FFB1560 0x40083145:0x3FFB1580 0x4008B622:0x3FFBA570 0x40083B51:0x3FFBA5B0 0x40083F21:0x3FFBA600 0x40083FF2:0x3FFBA630 0x400D6CD9:0x3FFBA650 0x400D6DB6:0x3FFBA6B0 0x400D6E85:0x3FFBA6E0 0x400D6C55:0x3FFBA710 0x400D683D:0x3FFBA730 0x400D60F9:0x3FFBA760 0x400D5B0C:0x3FFBA780 0x400872BD:0x3FFBA8A0
0x40085296: esp_crosscore_isr at /home/victor/software/esp-idf-v5.2.1/components/esp_system/crosscore_int.c:103
0x40083145: _xt_lowint1 at /home/victor/software/esp-idf-v5.2.1/components/xtensa/xtensa_vectors.S:1240
0x4008b622: spi_ll_set_miso_delay at /home/victor/software/esp-idf-v5.2.1/components/hal/esp32/include/hal/spi_ll.h:777
 (inlined by) spi_hal_setup_trans at /home/victor/software/esp-idf-v5.2.1/components/hal/spi_hal_iram.c:113
0x40083b51: spi_new_trans at /home/victor/software/esp-idf-v5.2.1/components/driver/spi/gpspi/spi_master.c:651
0x40083f21: spi_device_polling_start at /home/victor/software/esp-idf-v5.2.1/components/driver/spi/gpspi/spi_master.c:1129
0x40083ff2: spi_device_polling_transmit at /home/victor/software/esp-idf-v5.2.1/components/driver/spi/gpspi/spi_master.c:1184
0x400d6cd9: mipi_display_write_command at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl_hal/src/mipi_display.c:72
0x400d6db6: mipi_display_set_address at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl_hal/src/mipi_display.c:152
0x400d6e85: mipi_display_write at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl_hal/src/mipi_display.c:167
0x400d6c55: hline at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl_hal/src/hagl_hal_single.c:84
0x400d683d: hagl_fill_rectangle_xyxy at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl/src/hagl_rectangle.c:124
0x400d60f9: hagl_fill_rectangle at /media/victor/Data/Documents/code/esp_idf/esp_effects/components/hagl/include/hagl/rectangle.h:128
 (inlined by) plasma_render at /media/victor/Data/Documents/code/esp_idf/esp_effects/main/plasma.c:83
0x400d5b0c: demo_task at /media/victor/Data/Documents/code/esp_idf/esp_effects/main/main.c:181
0x400872bd: vPortTaskWrapper at /home/victor/software/esp-idf-v5.2.1/components/freertos/FreeRTOS-Kernel/portable/xtensa/port.c:134

```